### PR TITLE
1. Upgrade to dagster 1.5.10 to fix issues with pendulum.  dagster 1.…

### DIFF
--- a/dagster-dbt/setup.py
+++ b/dagster-dbt/setup.py
@@ -4,12 +4,12 @@ setup(
     name="postcard_company_dm",
     packages=find_packages(),
     install_requires=[
-        "dagster==1.4.10",
-        "dagster-dbt==0.20.10",
+        "dagster==1.5.10",
+        "dagster-dbt==0.21.10",
         "duckdb==0.8.1",
-        "dbt-core==1.4.7",
-        "dbt-duckdb==1.4.1",
-        "dagster-duckdb==0.20.10"
+        "dbt-core==1.7.7",
+        "dbt-duckdb==1.7.1",
+        "dagster-duckdb==0.21.10"
     ],
     extras_require={"dev": ["dagit", "pytest"]},
 )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,11 +10,11 @@ services:
     ports:
       - 54320:5432
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready", "-d", "sales_oltp"]
+      test: ["CMD-SHELL", "pg_isready -d sales_oltp --username $POSTGRES_USER"]
       interval: 30s
       timeout: 60s
       retries: 5
-      start_period: 80s
+      start_period: 45s
   generator:
     build:
       context: .
@@ -41,7 +41,7 @@ services:
         - ./dagster-dbt/postcard_company_dm:/dagster-dbt/postcard_company_dm
     ports:
         - "3000:3000"
-    command: dagit -h 0.0.0.0
+    command: dagster-webserver -h 0.0.0.0
     depends_on:
       generator:
         condition: service_completed_successfully


### PR DESCRIPTION
…5.7 introduced new warnings that were fixed in 1.5.10.

2. Change to oltp service healthcheck to remove 'role "root" does not exist' Fatal logs.
3. Use `dagster-webserver` instead of the deprecated `dagit` cli command.